### PR TITLE
Fixing a large number of indentations in a table

### DIFF
--- a/lua-parser/parser.lua
+++ b/lua-parser/parser.lua
@@ -214,8 +214,12 @@ local function sepBy (patt, sep, label)
   end
 end
 
+local function cut(s, idx, match)
+  return idx, match
+end
+
 local function chainOp (patt, sep, label)
-  return Cf(sepBy(patt, sep, label), binaryOp)
+  return Cmt(Cf(sepBy(patt, sep, label), binaryOp), cut)
 end
 
 local function commaSep (patt, label)

--- a/test.lua
+++ b/test.lua
@@ -3752,6 +3752,28 @@ e = [=[
 { `Set{ { `Id "gl_f_ct" }, { `Number "0" } }, `Set{ { `Id "f" }, { `Function{ {  }, { `If{ `Op{ "le", `Id "gl_f_ct", `Number "0" }, { `Set{ { `Id "gl_f_ct" }, { `Number "1" } }, `Return{ `Number "1000" } } }, `Return{ `Op{ "unm", `Number "1000" } } } } } }, `Call{ `Id "print", `Op{ "gt", `Call{ `Id "f", `String "1st call" }, `Call{ `Id "f", `String "2nd call" } } }, `Set{ { `Id "gl_f_ct" }, { `Number "0" } }, `Call{ `Id "print", `Op{ "lt", `Call{ `Id "f", `String "1st call" }, `Call{ `Id "f", `String "2nd call" } } } }
 ]=]
 
+-- table indentation
+
+s = [===[
+return {{{{{{{{{{{{{{{{}}}}}}}}}}}}}}}}
+]===]
+e = [=[
+{ `Return{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table } } } } } } } } } } } } } } } } }
+]=]
+
+r = parse(s)
+assert(r == e)
+
+s = [===[
+return {{{{{{{{{{{{{{{{{}}}}}}}}}}}}}}}}}
+]===]
+e = [=[
+{ `Return{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table{ `Table } } } } } } } } } } } } } } } } } }
+]=]
+
+r = parse(s)
+assert(r == e)
+
 r = parse(s)
 assert(r == e)
 


### PR DESCRIPTION
If the indentation was larger than 16, an error `subcapture nesting too deep` was thrown.

This fix is based on issues previously encountered by Neovim users:
- https://github.com/neovim/neovim/issues/26520
- https://github.com/neovim/neovim/pull/29520